### PR TITLE
Pass a Custom id field for service (serviceId)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,8 @@ function init (options = {}) {
     const oauth2Settings = merge({
       idField: `${name}Id`,
       path: `/auth/${name}`,
-      __oauth: true
+      __oauth: true,
+      serviceId: 'id'
     }, pick(authSettings, ...INCLUDE_KEYS), providerSettings, omit(options, ...EXCLUDE_KEYS));
 
     // Set callback defaults based on provided path

--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -43,7 +43,7 @@ class OAuth2Verifier {
   _updateEntity (entity, data) {
     const options = this.options;
     const name = options.name;
-    const id = entity[this.service.id];
+    const id = entity[this.service[options.serviceId]];
     debug(`Updating ${options.entity}: ${id}`);
 
     const newData = {
@@ -78,7 +78,7 @@ class OAuth2Verifier {
     const data = { profile, accessToken, refreshToken };
     let existing;
 
-    if (this.service.id === null || this.service.id === undefined) {
+    if (this.service[options.serviceId] === null || this.service[options.serviceId] === undefined) {
       debug('failed: the service.id was not set');
       return done(new Error('the `id` property must be set on the entity service for authentication'));
     }
@@ -108,7 +108,7 @@ class OAuth2Verifier {
       .then(this._normalizeResult)
       .then(entity => entity ? this._updateEntity(entity, data) : this._createEntity(data))
       .then(entity => {
-        const id = entity[this.service.id];
+        const id = entity[this.service.[options.serviceId]];
         const payload = { [`${this.options.entity}Id`]: id };
         done(null, entity, payload);
       })


### PR DESCRIPTION
### Summary

- [ ] Tell us about the problem your pull request is solving.

We use a custom id field for our feathers services (`_id`).  The verifier checks for the service id on the user object using the default `.id`.  In our case, it throws an error: 
`  debug('failed: the service.id was not set');`
Also, patches to the user record fail and the userId is not properly set in the token payload due to the same issue.

This may not best the solution, but we are proposing passing in an `serviceId` when configuring oauth2:

```
const oauth2Config = {
    name: 'sampleStrategry',
    Strategy: Strategy,
    clientID: config.clientID,
    clientSecret: config.clientSecret,
    passReqToCallback: true,
    // Pass in our custom service id
    serviceId: '_id'
};
```

This would default to `id` when not passed

- [ ] Are there any open issues that are related to this?

Nope.
- [ ] Is this PR dependent on PRs in other repos?

Not at the moment. If this solution is accepted I would open pull request in following packages for related issues:
- @feathersjs/authentication-oauth1
- @feathersjs/authentication/lib/socket

Thanks for all the hard work on feathersjs!