### PR TITLE
Allow a custom error Handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ function init (options = {}) {
     const Verifier = options.Verifier || DefaultVerifier;
     const formatter = options.formatter || rest.formatter;
     const handler = options.handler || defaultHandler(oauth2Settings);
-    const errorHandler = defaultErrorHandler(oauth2Settings);
+    const errorHandler =  options.errorHandler(oauth2Settings) || defaultErrorHandler(oauth2Settings);
 
     // register OAuth middleware
     debug(`Registering '${name}' Express OAuth middleware`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ function init (options = {}) {
     const Verifier = options.Verifier || DefaultVerifier;
     const formatter = options.formatter || rest.formatter;
     const handler = options.handler || defaultHandler(oauth2Settings);
-    const errorHandler =  options.errorHandler(oauth2Settings) || defaultErrorHandler(oauth2Settings);
+    const errorHandler = typeof options.errorHandler === 'function' ? options.errorHandler(oauth2Settings) : defaultErrorHandler(oauth2Settings);
 
     // register OAuth middleware
     debug(`Registering '${name}' Express OAuth middleware`);


### PR DESCRIPTION
I'd really need a way to customize the error redirect callback, based on the caught exception that triggered the fail. Simply allowing to have a custom errorHandler passed to the oauth() method when setting my authentication would allow me to do that.

This should be added to the documentation also.