### PR TITLE
Fix state=true in authorizationURL integrating passport-oauth2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,10 +70,10 @@ function init (options = {}) {
 
     // register OAuth middleware
     debug(`Registering '${name}' Express OAuth middleware`);
-    app.get(oauth2Settings.path, auth.express.authenticate(name, oauth2Settings));
+    app.get(oauth2Settings.path, auth.express.authenticate(name, omit(oauth2Settings, 'state')));
     app.get(
       oauth2Settings.callbackPath,
-      auth.express.authenticate(name, oauth2Settings),
+      auth.express.authenticate(name, omit(oauth2Settings, 'state')),
       handler,
       errorHandler,
       auth.express.emitEvents(authSettings),


### PR DESCRIPTION
### Summary

When integrating with a custom OAuth2 provider using `passport-oauth2` strategy, `state` option is set to `true` to support the authorization code grant flow and state verification.

However, since this option is also passed to the `authenticate` method of the `OAuth2Strategy` instance, which causes it to skip generating a random value and use the passed-in value directly instead, resulting in the current outcome.

### Other Information

Lines from passport-oauth2 that used state option directly in authorizationURL: https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L226-L234
