### PR TITLE
Allowing return type of _createEntity to be an Array

### DIFF
--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -108,7 +108,7 @@ class OAuth2Verifier {
       .then(this._normalizeResult)
       .then(entity => entity ? this._updateEntity(entity, data) : this._createEntity(data))
       .then(entity => {
-        const id = entity[this.service.id];
+        const id = Array.isArray(entity) ? entity[0][this.service.id] : entity[this.service.id];
         const payload = { [`${this.options.entity}Id`]: id };
         done(null, entity, payload);
       })


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
_createEntity might return an Array
- [ ] Are there any open issues that are related to this?
https://github.com/feathersjs/authentication-oauth2/issues/87
- [ ] Is this PR dependent on PRs in other repos?
No